### PR TITLE
ユーザにロールを追加

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,8 @@
 class Admin::UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
 
+  before_action :admin_flg
+
   def index
     @users = User.all.includes(:tasks).order(id: :asc)
   end
@@ -56,4 +58,9 @@ class Admin::UsersController < ApplicationController
   def set_user
     @user = User.find(params[:id])
   end
+
+  def admin_flg
+    raise Forbidden unless logged_in? && current_user.admin?
+  end
+
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,6 +3,8 @@ class Admin::UsersController < ApplicationController
 
   before_action :admin_flg
 
+  before_action :destroy_self, only: [:destroy]
+
   def index
     @users = User.all.includes(:tasks).order(id: :asc)
   end
@@ -61,6 +63,12 @@ class Admin::UsersController < ApplicationController
 
   def admin_flg
     raise Forbidden unless logged_in? && current_user.admin?
+  end
+
+  def destroy_self
+    if @user == current_user
+      redirect_to admin_users_path, notice: '自身を削除することは出来ません'
+    end
   end
 
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -52,7 +52,7 @@ class Admin::UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :password,
-                    :password_confirmation)
+                    :password_confirmation, :admin)
   end
 
   def set_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,15 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include SessionsHelper
 
+  class Forbidden < ActionController::ActionControllerError
+  end
+
+  rescue_from Forbidden, with: :rescue403
+
+  private
+
+  def rescue403(e)
+    @exception = e
+    render template: 'errors/forbidden', status: 403
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -10,5 +10,4 @@ module SessionsHelper
   def sign_in(user)
     self.current_user = user
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,14 @@ class User < ApplicationRecord
 
   has_secure_password
 
+  before_destroy :dont_delete_admin
+
+  private
+
+  def dont_delete_admin
+    if self.admin? && User.where(admin: true).count == 1
+      throw :abort
+    end
+  end
+
 end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -29,6 +29,11 @@
     <%= form.password_field :password, class: "form-control"  %>
   </div>
 
+  <div class="field">
+    <%= form.label :admin %>
+    <%= form.check_box :admin %>
+  </div>
+
 <br>
   <div class="actions">
     <%= form.submit class: "btn btn-primary" %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -11,6 +11,7 @@
       <th><%= t('view.username') %></th>
       <th><%= t('view.email') %></th>
       <th><%= t('view.task') %>数</th>
+      <th><%= t('view.admin') %></th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -22,6 +23,7 @@
         <td><%= user.name %></td>
         <td><%= user.email %></td>
         <td><%= user.tasks.count %></td>
+        <td><%= user.admin %></td>
         <td><%= link_to '詳細', admin_user_path(user) %></td>
         <td><%= link_to '編集', edit_admin_user_path(user) %></td>
         <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -26,7 +26,7 @@
         <td><%= user.admin %></td>
         <td><%= link_to '詳細', admin_user_path(user) %></td>
         <td><%= link_to '編集', edit_admin_user_path(user) %></td>
-        <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to '削除', admin_user_path(user), method: :delete, data: { confirm: '本当に削除しますか?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,5 @@
+<h5>このページにアクセスする権限がありません。</h5>
+<br>
+<br>
+<br>
+<%= link_to 'タスク一覧に戻る', tasks_path, class: "btn btn-outline-dark btn-sm" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,13 +11,16 @@
 
   <body>
 
-
     <nav class="navbar navbar-expand navbar-dark bg-dark fixed-top">
       <%= link_to 'タスク管理ツール', request.path, id: "logo", class: "navbar-brand mr-auto" %>
+      <% if logged_in? && current_user.admin? %>
+        <%= link_to '管理画面', admin_users_path, class: "nav-item" %>
+        &nbsp;
+      <% end %>
       <% if logged_in? %>
-          <%= link_to current_user.name, user_path(current_user.id), class: "nav-item" %></li>
+          <%= link_to current_user.name, user_path(current_user.id), class: "nav-item" %>
           &nbsp;
-          <%= link_to t('view.logout'), session_path(current_user.id), method: :delete, class: "nav-item" %></li>
+          <%= link_to t('view.logout'), session_path(current_user.id), method: :delete, class: "nav-item" %>
       <% end %>
     </nav>
 

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -21,5 +21,6 @@ ja:
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "確認用パスワード"
+        admin: "管理者"
       label:
         name: "ラベル名"

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -17,6 +17,7 @@ ja:
     login: "ログイン"
     password: "パスワード"
     logout: "ログアウト"
+    admin: "管理者"
   views:
     pagination:
       truncate: "..."

--- a/db/migrate/20190716080118_add_column_to_user_admin.rb
+++ b/db/migrate/20190716080118_add_column_to_user_admin.rb
@@ -1,0 +1,5 @@
+class AddColumnToUserAdmin < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_14_070530) do
+ActiveRecord::Schema.define(version: 2019_07_16_080118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2019_07_14_070530) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION

#34

- ユーザを管理ユーザと一般ユーザに分ける
- 管理ユーザだけがユーザ管理画面にアクセス
- 一般ユーザが管理画面にアクセスした場合、専用の例外（エラー）を出力
- ユーザ管理画面でロールの付与と削除
- 管理ユーザが1人もいなくならないように削除の制御
