### PR TITLE
グループを設定できるようにする

### DIFF
--- a/app/assets/javascripts/groupings.coffee
+++ b/app/assets/javascripts/groupings.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/groups.coffee
+++ b/app/assets/javascripts/groups.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,11 @@
 body {
     margin-top: 100px;
   }
+
+  a:link {
+    color: #C71585;
+  }
+
+  a:visited {
+    color: #8A2BE2;
+  }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,11 +4,3 @@
 body {
     margin-top: 100px;
   }
-
-  a:link {
-    color: #C71585;
-  }
-
-  a:visited {
-    color: #C71585;
-  }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,5 +10,5 @@ body {
   }
 
   a:visited {
-    color: #8A2BE2;
+    color: #C71585;
   }

--- a/app/assets/stylesheets/groupings.scss
+++ b/app/assets/stylesheets/groupings.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Groupings controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/groups.scss
+++ b/app/assets/stylesheets/groups.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Groups controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -1,0 +1,14 @@
+class GroupingsController < ApplicationController
+  def create
+    grouping = current_user.groupings.create(group_id: params[:group_id])
+    redirect_to groups_path, notice: "#{grouping.group.name}に参加しました"
+  end
+
+  def destroy
+    grouping = current_user.groupings.find_by(id: params[:id]).destroy
+    redirect_to groups_path, notice: "#{grouping.group.name}から退会しました"
+  end
+end
+
+
+# グループから退会ではなく、グループそのものを削除している

--- a/app/controllers/groupings_controller.rb
+++ b/app/controllers/groupings_controller.rb
@@ -5,10 +5,11 @@ class GroupingsController < ApplicationController
   end
 
   def destroy
-    grouping = current_user.groupings.find_by(id: params[:id]).destroy
-    redirect_to groups_path, notice: "#{grouping.group.name}から退会しました"
+    if current_user.user_groups.find_by(owner_id: current_user.id)
+      redirect_to groups_path, notice: "グループの作成者はグループから離脱出来ません"
+    else
+      grouping = current_user.groupings.find_by(id: params[:id]).destroy
+      redirect_to groups_path, notice: "#{grouping.group.name}から離脱しました"
+    end
   end
 end
-
-
-# グループから退会ではなく、グループそのものを削除している

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,6 +3,7 @@ class GroupsController < ApplicationController
   before_action :set_group, only: [:show, :edit, :update, :destroy]
   before_action :edit_group, only: [:edit, :update, :destroy]
   before_action :sign_in_user
+  before_action :user_in_group, only: [:show]
 
   def index
     @groups = Group.all
@@ -71,4 +72,11 @@ class GroupsController < ApplicationController
   def sign_in_user
     redirect_to new_session_path unless logged_in?
   end
+
+  def user_in_group
+    unless @group.group_users.ids.include?(current_user.id)
+      redirect_to groups_path, notice: '詳細画面はグループメンバーのみ参照できます'
+    end
+  end
+
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,6 +2,8 @@ class GroupsController < ApplicationController
 
   before_action :set_group, only: [:show, :edit, :update, :destroy]
 
+  before_action :edit_group, only: [:edit, :update, :destroy]
+
   def index
     @groups = Group.all
   end
@@ -17,6 +19,7 @@ class GroupsController < ApplicationController
 
   def create
     @group = Group.new(group_params)
+    @group.owner_id = current_user.id
     if @group.save
       redirect_to groups_path, notice: "グループを作成しました!"
     else
@@ -51,10 +54,16 @@ class GroupsController < ApplicationController
   private
 
   def group_params
-    params.require(:group).permit(:name, :info)
+    params.require(:group).permit(:name, :info, :owner_id, user_ids:[])
   end
 
   def set_group
     @group = Group.find(params[:id])
+  end
+
+  def edit_group
+    if @group.owner_id != current_user.id
+      redirect_to groups_path, notice: 'グループの編集は作成者のみが行えます'
+    end
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,6 +4,7 @@ class GroupsController < ApplicationController
 
   def index
     @groups = Group.all
+  end
 
   def new
     if params[:back]

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,59 @@
+class GroupsController < ApplicationController
+
+  before_action :set_group, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @groups = Group.all
+
+  def new
+    if params[:back]
+      @group = Group.new(group_params)
+    else
+      @group = Group.new
+      @group.groupings.build
+    end
+  end
+
+  def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to groups_path, notice: "グループを作成しました!"
+    else
+      render 'new'
+    end
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @group.update(group_params)
+      redirect_to groups_path, notice: "グループを編集しました！"
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @group.destroy
+    redirect_to groups_path, notice: "グループを削除しました！"
+  end
+
+  def confirm
+    @group = Group.new(group_params)
+    render :new if @group.invalid?
+  end
+
+  private
+
+  def group_params
+    params.require(:group).permit(:name, :info)
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,6 +22,7 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
     @group.owner_id = current_user.id
+    @group.groupings.build(user_id: current_user.id, group_id: @group.id)
     if @group.save
       redirect_to groups_path, notice: "グループを作成しました!"
     else

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -31,6 +31,9 @@ class GroupsController < ApplicationController
   end
 
   def show
+    groupusers = @group.group_users.ids
+    @tasks = Task.where(:user_id => groupusers)
+    @tasks = @tasks.page(params[:page]).per(10)
   end
 
   def edit

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,11 +1,12 @@
 class GroupsController < ApplicationController
 
   before_action :set_group, only: [:show, :edit, :update, :destroy]
-
   before_action :edit_group, only: [:edit, :update, :destroy]
+  before_action :sign_in_user
 
   def index
     @groups = Group.all
+    @grouping = current_user.groupings.find_by(user_id: current_user.id)
   end
 
   def new
@@ -65,5 +66,9 @@ class GroupsController < ApplicationController
     if @group.owner_id != current_user.id
       redirect_to groups_path, notice: 'グループの編集は作成者のみが行えます'
     end
+  end
+
+  def sign_in_user
+    redirect_to new_session_path unless logged_in?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :password,
-                    :password_confirmation)
+                    :password_confirmation, group_ids:[])
   end
 
 end

--- a/app/helpers/groupings_helper.rb
+++ b/app/helpers/groupings_helper.rb
@@ -1,0 +1,2 @@
+module GroupingsHelper
+end

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,0 +1,2 @@
+module GroupsHelper
+end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -2,6 +2,6 @@ module TasksHelper
   def time_alert
     expire_date = Time.zone.today + 3
     @expirations = Task.all.where(user_id: current_user.id).where("endtime <= ?",  expire_date).where.not(status: :done)
-    return @expirations
+    return @expirations if @expirations.present?
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,3 @@
 class Group < ApplicationRecord
-  belongs_to :grouping
+  has_many :groupings, dependent: :destroy, foreign_key: 'group_id'
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,5 @@
 class Group < ApplicationRecord
-  has_many :groupings, dependent: :destroy, foreign_key: 'group_id'
+#  has_many :groupings, dependent: :destroy, foreign_key: 'group_id'
+  has_many :groupings, dependent: :destroy
   has_many :group_users, through: :groupings, source: :user
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,4 @@
 class Group < ApplicationRecord
   has_many :groupings, dependent: :destroy, foreign_key: 'group_id'
+  has_many :group_users, through: :groupings, source: :user
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,3 @@
+class Group < ApplicationRecord
+  belongs_to :grouping
+end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -1,0 +1,2 @@
+class Grouping < ApplicationRecord
+end

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -1,2 +1,4 @@
 class Grouping < ApplicationRecord
+  belongs_to :group, optional: true
+  belongs_to :user, optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,8 @@
 class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   has_many :labels, dependent: :destroy
-  has_many :groupings, dependent: :destroy, foreign_key: 'user_id'
+#  has_many :groupings, dependent: :destroy, foreign_key: 'user_id'
+  has_many :groupings, dependent: :destroy
   has_many :user_groups, through: :groupings, source: :group
 
   before_validation { email.downcase! }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   has_many :labels, dependent: :destroy
+  has_many :groupings, dependent: :destroy, foreign_key: 'user_id'
 
   before_validation { email.downcase! }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   has_many :labels, dependent: :destroy
   has_many :groupings, dependent: :destroy, foreign_key: 'user_id'
+  has_many :user_groups, through: :groupings, source: :group
 
   before_validation { email.downcase! }
 

--- a/app/views/groupings/create.html.erb
+++ b/app/views/groupings/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Groupings#create</h1>
+<p>Find me in app/views/groupings/create.html.erb</p>

--- a/app/views/groupings/destroy.html.erb
+++ b/app/views/groupings/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Groupings#destroy</h1>
+<p>Find me in app/views/groupings/destroy.html.erb</p>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,0 +1,30 @@
+<div class="form-group">
+<%= form_with(model: group, local: true) do |form| %>
+  <% if group.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(group.errors.count, "error") %> が存在しているため保存出来ません:</h2>
+
+      <ul>
+      <% group.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name, class: "form-control" %>
+  </div>
+
+  <div class="field">
+    <%= form.label :info %>
+    <%= form.text_area :info, class: "form-control"  %>
+  </div>
+
+<br>
+  <div class="actions">
+    <%= form.submit class: "btn btn-primary" %>
+  </div>
+<% end %>
+</div>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,0 +1,6 @@
+<h4><%= t('view.group') %><%= t('view.edit') %></h4>
+
+<%= render 'form', group: @group %>
+
+<%= link_to '詳細', @group, class: "btn btn-outline-dark btn-sm" %>
+<%= link_to '戻る', groups_path, class: "btn btn-outline-dark btn-sm" %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,0 +1,26 @@
+<h4><%= t('view.group') %><%= t('view.index') %></h4>
+<div style="text-align: right">
+<%= link_to 'グループ新規作成', new_group_path, class: "btn btn-dark btn-sm"  %>
+</div>
+
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th><%= t('view.groupname') %></th>
+      <th><%= t('view.groupinfo') %></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @groups.each do |group| %>
+      <tr>
+        <td><%= group.name %></td>
+        <td><%= group.info %></td>
+        <td><%= link_to '詳細', group %></td>
+        <td><%= link_to '編集', edit_group_path(group) %></td>
+        <td><%= link_to '削除', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -18,12 +18,17 @@
       <tr>
         <td><%= group.name %></td>
         <td><%= group.info %></td>
+        <% if group.owner_id == current_user.id %>
+        <td>
+        </td>
+        <% else %>
         <td>
           <% if group.group_users.find_by(id: current_user.id) %>
             <%= link_to 'グループから抜ける', grouping_path(id: @grouping.id), method: :delete, class: 'btn btn-outline-danger btn-sm' %>
           <% else %>
             <%= link_to 'グループに参加する', groupings_path(group_id: group.id), method: :post, class: 'btn btn-outline-primary btn-sm' %>
           <% end %>
+        <% end %>
         <td>
           <% if group.group_users.ids.include?(current_user.id) %>
             <%= link_to '詳細', group %></td>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -24,9 +24,21 @@
           <% else %>
             <%= link_to 'グループに参加する', groupings_path(group_id: group.id), method: :post, class: 'btn btn-outline-primary btn-sm' %>
           <% end %>
-        <td><%= link_to '詳細', group %></td>
-        <td><%= link_to '編集', edit_group_path(group) %></td>
-        <td><%= link_to '削除', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td>
+          <% if group.group_users.ids.include?(current_user.id) %>
+            <%= link_to '詳細', group %></td>
+          <% end %>
+        <% if group.owner_id == current_user.id %>
+        <td>
+          <%= link_to '編集', edit_group_path(group) %>
+        </td>
+        <td>
+          <%= link_to '削除', group, method: :delete, data: { confirm: 'Are you sure?' } %>
+        </td>
+        <% else %>
+        <td colspan="2" >
+        </td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -8,6 +8,7 @@
     <tr>
       <th><%= t('view.groupname') %></th>
       <th><%= t('view.groupinfo') %></th>
+      <th></th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -17,6 +18,12 @@
       <tr>
         <td><%= group.name %></td>
         <td><%= group.info %></td>
+        <td>
+          <% if group.group_users.find_by(id: current_user.id) %>
+            <%= link_to 'グループから抜ける', grouping_path(id: @grouping.id), method: :delete, class: 'btn btn-outline-danger btn-sm' %>
+          <% else %>
+            <%= link_to 'グループに参加する', groupings_path(group_id: group.id), method: :post, class: 'btn btn-outline-primary btn-sm' %>
+          <% end %>
         <td><%= link_to '詳細', group %></td>
         <td><%= link_to '編集', edit_group_path(group) %></td>
         <td><%= link_to '削除', group, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -18,33 +18,36 @@
       <tr>
         <td><%= group.name %></td>
         <td><%= group.info %></td>
-        <% if group.owner_id == current_user.id %>
         <td>
+      <% if group.owner_id == current_user.id %>
         </td>
+      <% else %>
+        <% if group.group_users.find_by(id: current_user.id) %>
+          <%= link_to 'グループから抜ける', grouping_path(id: @grouping.id), method: :delete, data: { confirm: 'グループから抜けますか?' }, class: 'btn btn-outline-danger btn-sm' %>
         <% else %>
-        <td>
-          <% if group.group_users.find_by(id: current_user.id) %>
-            <%= link_to 'グループから抜ける', grouping_path(id: @grouping.id), method: :delete, class: 'btn btn-outline-danger btn-sm' %>
-          <% else %>
-            <%= link_to 'グループに参加する', groupings_path(group_id: group.id), method: :post, class: 'btn btn-outline-primary btn-sm' %>
-          <% end %>
+          <%= link_to 'グループに参加する', groupings_path(group_id: group.id), method: :post, data: { confirm: 'グループに参加しますか?' }, class: 'btn btn-outline-secondary btn-sm' %>
         <% end %>
+        </td>
+      <% end %>
+      <% if group.group_users.ids.include?(current_user.id) %>
         <td>
-          <% if group.group_users.ids.include?(current_user.id) %>
-            <%= link_to '詳細', group %></td>
-          <% end %>
-        <% if group.owner_id == current_user.id %>
+          <%= link_to '詳細', group %>
+        </td>
+      <% else %>
+        <td></td>
+      <% end %>
+      <% if group.owner_id == current_user.id %>
         <td>
           <%= link_to '編集', edit_group_path(group) %>
         </td>
         <td>
-          <%= link_to '削除', group, method: :delete, data: { confirm: 'Are you sure?' } %>
+          <%= link_to '削除', group, method: :delete, data: { confirm: 'グループを削除しますか?' } %>
         </td>
-        <% else %>
+      <% else %>
         <td colspan="2" >
         </td>
-        <% end %>
-      </tr>
+      <% end %>
+    </tr>
     <% end %>
   </tbody>
 </table>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,0 +1,5 @@
+<h4><%= t('view.group') %><%= t('view.create') %></h4>
+
+<%= render 'form', group: @group, class: "btn btn-outline-dark btn-sm"  %>
+
+<%= link_to '戻る', groups_path, class: "btn btn-outline-dark btn-sm"  %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,22 +1,65 @@
 <p id="notice"><%= notice %></p>
 
 <table class="table">
-<tr>
-<th>
-  <%= t('view.groupname') %>
-  </th>
-  <td>
-  <%= @group.name %>
-</td>
-</tr>
-<tr>
-<th>
-  <%= t('view.groupinfo') %>
-</th>
-<td>
-  <%= @group.info %>
-</td>
-</tr>
+  <tr>
+    <th>
+      <%= t('view.groupname') %>
+    </th>
+    <td>
+      <%= @group.name %>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      <%= t('view.groupinfo') %>
+    </th>
+    <td>
+      <%= @group.info %>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      <%= t('view.user') %><%= t('view.index') %>
+    </th>
+    <td>
+      <% @group.group_users.map(&:name).each do |name| %>
+        <%= name %>
+      <% end %> 
+    </td>
+  </tr>
 </table>
 <%= link_to '編集', edit_group_path(@group), class: "btn btn-outline-dark btn-sm"  %>
 <%= link_to '戻る', groups_path, class: "btn btn-outline-dark btn-sm"  %>
+
+<br>
+<hr>
+<br>
+
+<h5><%= @group.name %><%= t('view.task') %><%= t('view.index') %></h5>
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th><%= t('view.username') %></th>
+      <th><%= t('view.taskname') %></th>
+      <th><%= t('view.taskdetail') %></th>
+      <th><%= t('view.endtime') %></th>
+      <th><%= t('view.status') %></th>
+      <th><%= t('view.priority') %></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= task.user.name %></td>
+        <td><%= task.name %></td>
+        <td><%= task.detail %></td>
+        <td><%= task.endtime %></td>
+        <td><%= task.aasm.human_state %></td>
+        <td><%= task.priority  %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @tasks %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,0 +1,22 @@
+<p id="notice"><%= notice %></p>
+
+<table class="table">
+<tr>
+<th>
+  <%= t('view.groupname') %>
+  </th>
+  <td>
+  <%= @group.name %>
+</td>
+</tr>
+<tr>
+<th>
+  <%= t('view.groupinfo') %>
+</th>
+<td>
+  <%= @group.info %>
+</td>
+</tr>
+</table>
+<%= link_to '編集', edit_group_path(@group), class: "btn btn-outline-dark btn-sm"  %>
+<%= link_to '戻る', groups_path, class: "btn btn-outline-dark btn-sm"  %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,9 +16,14 @@
       <% if logged_in? && current_user.admin? %>
         <%= link_to '管理画面', admin_users_path, class: "nav-item" %>
         &nbsp;
+        &nbsp;
       <% end %>
       <% if logged_in? %>
           <%= link_to current_user.name, user_path(current_user.id), class: "nav-item" %>
+          &nbsp;
+          &nbsp;
+          <%= link_to t('view.group'), groups_path, class: "nav-item" %>
+          &nbsp;
           &nbsp;
           <%= link_to t('view.logout'), session_path(current_user.id), method: :delete, class: "nav-item" %>
       <% end %>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -36,7 +36,7 @@
     <%= form.label :priority %>
     <%= form.select :priority, Task.priorities.keys.to_a,{}, {class: "form-control"} %>
   </div>
-
+<br>
 <%= t('view.label') %>
 <br>
 <% label_list.each do |label| %>
@@ -51,6 +51,7 @@
 <br>
 <%= link_to '新しくラベルを作成', new_label_path, class: "btn btn-outline-dark btn-sm"  %>
 <br>
+<hr>
 <br>
   <div class="actions">
     <%= form.submit class: "btn btn-primary" %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -72,6 +72,4 @@
 <%= paginate @tasks %>
 
 <br>
-
-
 <br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,19 +1,30 @@
 <table class="table">
-<tr>
-<th>
-  <%= t('view.username') %>
-  </th>
-  <td>
-  <%= @user.name %>
-</td>
-</tr>
-<tr>
-<th>
-  <%= t('view.email') %>
-</th>
-<td>
-  <%= @user.email %>
-</td>
-</tr>
+  <tr>
+    <th>
+      <%= t('view.username') %>
+    </th>
+    <td>
+      <%= @user.name %>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      <%= t('view.email') %>
+    </th>
+    <td>
+      <%= @user.email %>
+    </td>
+  </tr>
+  <tr>
+    <th>
+      <%= t('view.group') %>
+    </th>
+    <td>
+      <% @user.user_groups.map(&:name).each do |name| %>
+        <%= name %>
+      <% end %>
+    </td>
+  </tr>
+
 </table>
 <%= link_to '戻る', tasks_path, class: "btn btn-outline-dark btn-sm"  %>

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -4,6 +4,7 @@ ja:
       task: "タスク"
       user: "ユーザ"
       label: "ラベル"
+      group: "グループ"
     attributes:
       task:
         name: "タスク名"
@@ -24,3 +25,6 @@ ja:
         admin: "管理者"
       label:
         name: "ラベル名"
+      group:
+        name: "グループ名"
+        info: "グループ情報"

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -19,6 +19,7 @@ ja:
     logout: "ログアウト"
     admin: "管理者"
     label: "ラベル"
+    group: "グループ"
     groupname: "グループ名"
     groupinfo: "グループ情報"
   views:

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -19,6 +19,8 @@ ja:
     logout: "ログアウト"
     admin: "管理者"
     label: "ラベル"
+    groupname: "グループ名"
+    groupinfo: "グループ情報"
   views:
     pagination:
       truncate: "..."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users
   end
+
+  resources :groupings, only: [:create, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :tasks
   resources :users, only:[:new, :create, :show]
   resources :sessions, only:[:new, :create, :destroy ]
+  resources :groups
 
   namespace :admin do
     resources :users

--- a/db/migrate/20190817070852_create_groupings.rb
+++ b/db/migrate/20190817070852_create_groupings.rb
@@ -1,0 +1,12 @@
+class CreateGroupings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :groupings do |t|
+      t.integer :user_id
+      t.integer :group_id
+
+      t.timestamps
+    end
+    add_index :groupings, :user_id
+    add_index :groupings, :group_id
+  end
+end

--- a/db/migrate/20190817070916_create_groups.rb
+++ b/db/migrate/20190817070916_create_groups.rb
@@ -3,6 +3,7 @@ class CreateGroups < ActiveRecord::Migration[5.2]
     create_table :groups do |t|
       t.string :name
       t.text :info
+      t.integer :user_id
       t.references :grouping, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20190817070916_create_groups.rb
+++ b/db/migrate/20190817070916_create_groups.rb
@@ -1,0 +1,11 @@
+class CreateGroups < ActiveRecord::Migration[5.2]
+  def change
+    create_table :groups do |t|
+      t.string :name
+      t.text :info
+      t.references :grouping, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190817070916_create_groups.rb
+++ b/db/migrate/20190817070916_create_groups.rb
@@ -3,7 +3,7 @@ class CreateGroups < ActiveRecord::Migration[5.2]
     create_table :groups do |t|
       t.string :name
       t.text :info
-      t.integer :user_id
+      t.integer :owner_id
       t.references :grouping, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20190817071127_add_group_ref_to_users.rb
+++ b/db/migrate/20190817071127_add_group_ref_to_users.rb
@@ -1,5 +1,5 @@
 class AddGroupRefToUsers < ActiveRecord::Migration[5.2]
   def change
-    add_reference :users, :grouping, foreign_key: true
+    add_reference :users, :grouping
   end
 end

--- a/db/migrate/20190817071127_add_group_ref_to_users.rb
+++ b/db/migrate/20190817071127_add_group_ref_to_users.rb
@@ -1,6 +1,5 @@
 class AddGroupRefToUsers < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :group_id, :integer
     add_reference :users, :grouping, foreign_key: true
   end
 end

--- a/db/migrate/20190817071127_add_group_ref_to_users.rb
+++ b/db/migrate/20190817071127_add_group_ref_to_users.rb
@@ -1,5 +1,6 @@
 class AddGroupRefToUsers < ActiveRecord::Migration[5.2]
   def change
+    add_column :users, :group_id, :integer
     add_reference :users, :grouping, foreign_key: true
   end
 end

--- a/db/migrate/20190817071127_add_group_ref_to_users.rb
+++ b/db/migrate/20190817071127_add_group_ref_to_users.rb
@@ -1,0 +1,5 @@
+class AddGroupRefToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :users, :grouping, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,5 +76,4 @@ ActiveRecord::Schema.define(version: 2019_08_17_071127) do
 
   add_foreign_key "groups", "groupings"
   add_foreign_key "labels", "users"
-  add_foreign_key "users", "groupings"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2019_08_17_071127) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.text "info"
+    t.integer "user_id"
     t.bigint "grouping_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -68,6 +69,7 @@ ActiveRecord::Schema.define(version: 2019_08_17_071127) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false, null: false
+    t.integer "group_id"
     t.bigint "grouping_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["grouping_id"], name: "index_users_on_grouping_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2019_08_17_071127) do
   create_table "groups", force: :cascade do |t|
     t.string "name"
     t.text "info"
-    t.integer "user_id"
+    t.integer "owner_id"
     t.bigint "grouping_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -69,7 +69,6 @@ ActiveRecord::Schema.define(version: 2019_08_17_071127) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false, null: false
-    t.integer "group_id"
     t.bigint "grouping_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["grouping_id"], name: "index_users_on_grouping_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_24_203556) do
+ActiveRecord::Schema.define(version: 2019_08_17_071127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "groupings", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_groupings_on_group_id"
+    t.index ["user_id"], name: "index_groupings_on_user_id"
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "name"
+    t.text "info"
+    t.bigint "grouping_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grouping_id"], name: "index_groups_on_grouping_id"
+  end
 
   create_table "labelings", force: :cascade do |t|
     t.integer "task_id"
@@ -50,8 +68,12 @@ ActiveRecord::Schema.define(version: 2019_07_24_203556) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false, null: false
+    t.bigint "grouping_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["grouping_id"], name: "index_users_on_grouping_id"
   end
 
+  add_foreign_key "groups", "groupings"
   add_foreign_key "labels", "users"
+  add_foreign_key "users", "groupings"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,16 +6,14 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-
-#50.times do |no|
-#  Task.create(:name => "タイトル #{no}", :detail => "詳細 #{no}")
-#end
-
 User.create!(name: "admin_user", email: "admin@example.com", password: "taskapp", admin: true)
-Group.create!(name: "first_group", info: "The first group", owner_id: 1)
 
 Label.create(name: "仕事")
 Label.create(name: "趣味")
 Label.create(name: "家事")
 Label.create(name: "緊急")
 Label.create(name: "その他")
+
+10.times do |no|
+  Task.create(:name => "タイトル #{no}", :detail => "詳細 #{no}", :user_id => 1)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,7 @@
 #end
 
 User.create!(name: "admin_user", email: "admin@example.com", password: "taskapp", admin: true)
+Group.create!(name: "first_group", info: "The first group", owner_id: 1)
 
 Label.create(name: "仕事")
 Label.create(name: "趣味")

--- a/spec/factories/groupings.rb
+++ b/spec/factories/groupings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :grouping do
+    user_id { 1 }
+    group_id { 1 }
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :group do
+    name { "MyString" }
+    info { "MyText" }
+    grouping { nil }
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/grouping_spec.rb
+++ b/spec/models/grouping_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Grouping, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
#42

- グループ作成機能追加
- グループ情報の編集や削除はそのグループの作成者のみができるよう制限
- グループに自由にユーザーが参加できるようにする
- グループの詳細画面にはそのグループの参加者のみが行けるように制限
- ユーザーは複数のグループに参加できるものとする。また、離脱できるものとする
- グループの作成者は、最初からそのグループに参加しているものとして扱い、離脱もできないようにする
- グループの詳細画面で、そのグループのユーザーたちが持っているタスクを参照できるようにする